### PR TITLE
Fix and enable cutting out of sub-grid pieces.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,8 @@ Options are:
 
 * ``-l``: Scale. Use numbers less than 1 to scale down, e.g. 0.5 is half scale.
 
+* ``-ix,iy,iw,ih``: Sub-grid, use to cut out a certain piece from the input map. ``x,y`` define lower-left corner and ``w,h`` the width and height of the cut-out.
+
 
 Commandline Examples
 --------------------

--- a/lidartile/cli.py
+++ b/lidartile/cli.py
@@ -18,11 +18,17 @@ def main():
     parser.add_argument("-m", "--smoothing", type=float, default=0)
     parser.add_argument("-l", "--scale", type=float, default=0.3)
     parser.add_argument("-o", "--output", default="output.stl")
+    parser.add_argument("-ix", "--slicex", type=int, default=0)
+    parser.add_argument("-iy", "--slicey", type=int, default=0)
+    parser.add_argument("-iw", "--slicewidth", type=int, default=0)
+    parser.add_argument("-ih", "--sliceheight", type=int, default=0)
     parser.add_argument("files", nargs="+")
     args = parser.parse_args()
 
     ingestor = AscIngestor(args.files, divisor=args.divisor, zboost=args.zboost)
     ingestor.load()
+    if args.slicewidth and args.sliceheight:
+        ingestor.grid = ingestor.grid.slice(args.slicex, args.slicey, args.slicewidth, args.sliceheight)
     grid = ingestor.grid
     if args.clip:
         print "Clipping..."

--- a/lidartile/grid.py
+++ b/lidartile/grid.py
@@ -50,16 +50,16 @@ class Grid(object):
                 limit = s * (1 / factor)
                 self[x, y] = clip(height, m - limit, m + limit)
 
-    def slice(self, x, y, w, h):
+    def slice(self, ox, oy, w, h):
         """
         Returns a sub-grid
         """
-        assert x + w <= self.width
-        assert y + h <= self.height
+        assert ox + w <= self.width
+        assert oy + h <= self.height
         result = self.__class__(w, h)
-        for y in range(y, y + h):
-            idx = x + (y * w)
-            ouridx = x + (y * self.width)
+        for y in range(0, h):
+            idx = 0 + (y * w)
+            ouridx = ox + ((oy+y) * self.width)
             result.data[idx:idx+w] = self.data[ouridx:ouridx+w]
         return result
 

--- a/lidartile/grid.py
+++ b/lidartile/grid.py
@@ -57,8 +57,8 @@ class Grid(object):
         assert ox + w <= self.width
         assert oy + h <= self.height
         result = self.__class__(w, h)
-        for y in range(0, h):
-            idx = 0 + (y * w)
+        for y in range(h):
+            idx = y * w
             ouridx = ox + ((oy+y) * self.width)
             result.data[idx:idx+w] = self.data[ouridx:ouridx+w]
         return result


### PR DESCRIPTION
My little project required an easy way to arbitrarily cut a bigger map into sub-tiles. Introducing new command line arguments and fixing up the slicing code makes this super easy.